### PR TITLE
Update template to work also with new CESNET logging server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ remote_logging_enabled: true
 # name of remote server
 remote_logging_server: vinovago.cesnet.cz
 
+# mechanism used for remote logging
+remote_logging_protocol: network
+
 # TCP port of remote server
 remote_logging_port: 514
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,13 @@ remote_logging_filter: ""
 # TLS settings
 remote_logging_client_key_file: /etc/perun/ssl/hostkey.pem
 remote_logging_client_cert_file: /etc/perun/ssl/hostcert.pem
+
+# Disk buffer prevents data loss if destination log server is temporarily not available
+remote_logging_disk_buffer: no
+# is reliable=yes, all messages are written to the disk first
+remote_logging_disk_buffer_reliable: 'yes'
+# size in bytes for the disk buffer, default is minimum 1048576 bytes (1 MiB), we use 5GB
+remote_logging_disk_buffer_size: 5000000000
+# size of the messages in bytes that is used in the memory part of the disk buffer (cca 163 MB)
+remote_logging_disk_buffer_size_mem: 163840000
+

--- a/templates/remote_logging.j2
+++ b/templates/remote_logging.j2
@@ -1,7 +1,7 @@
 # Configure the remote destination
 # see https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.38/administration-guide/tls-encrypted-message-transfer/tls-options/
 destination d_{{ remote_logging_conf }} {
-    network(
+    {{ remote_logging_protocol }}(
         "{{ remote_logging_server }}"
         port({{ remote_logging_port }})
         transport("tls")
@@ -11,6 +11,10 @@ destination d_{{ remote_logging_conf }} {
             ca_dir("/etc/ssl/certs")
             trusted-dn("CN={{ remote_logging_server }}, *")
         )
+{% if remote_logging_protocol == 'syslog' %}
+        ip-protocol(6)
+        flags(syslog-protocol)
+{% endif %}
         flush_lines(100)
         # workaround for Java exceptions containing multiple lines
         flags(no-multi-line)

--- a/templates/remote_logging.j2
+++ b/templates/remote_logging.j2
@@ -15,6 +15,13 @@ destination d_{{ remote_logging_conf }} {
         ip-protocol(6)
         flags(syslog-protocol)
 {% endif %}
+{% if remote_logging_enable_disk_buffer %}
+        disk-buffer(
+            mem-buf-size({{ remote_logging_disk_buffer_size_mem }})
+            disk-buf-size({{ remote_logging_disk_buffer_size }})
+            reliable({{ remote_logging_disk_buffer_reliable }})
+	    )
+{% endif %}
         flush_lines(100)
         # workaround for Java exceptions containing multiple lines
         flags(no-multi-line)


### PR DESCRIPTION
- We can now specify protocol used to send logs to remote logserver (network/syslog).
- Default to "network" which is used on vinovago.
- Allow to enabled disk buffer to make sure no log message is lost when remote server is not available.